### PR TITLE
Remove HTTP service

### DIFF
--- a/etc/haproxy/haproxy.cfg
+++ b/etc/haproxy/haproxy.cfg
@@ -5,7 +5,6 @@ defaults
     timeout server  50000
 
 frontend http-in
-    bind *:80
     bind *:443 ssl crt /etc/ssl/private/reciperadar.com.pem alpn h2,http/1.1
     redirect scheme https if !{ ssl_fc }
 

--- a/etc/haproxy/haproxy.cfg
+++ b/etc/haproxy/haproxy.cfg
@@ -6,7 +6,6 @@ defaults
 
 frontend http-in
     bind *:443 ssl crt /etc/ssl/private/reciperadar.com.pem alpn h2,http/1.1
-    redirect scheme https if !{ ssl_fc }
 
     acl blog_request hdr_beg(host) blog.
     use_backend blog if blog_request

--- a/etc/systemd/system/ngrok.service
+++ b/etc/systemd/system/ngrok.service
@@ -4,10 +4,9 @@ After=network.target
 
 [Service]
 Restart=always
-RestartSec=30
+RestartSec=5
 User=ngrok
-ExecStart=/usr/bin/ssh -R reciperadar.com:80:localhost:80 tunnel.eu.ngrok.com http -bind-tls=false
-# ExecStart=/usr/bin/ssh -R www.reciperadar.com:443:localhost:443 tunnel.eu.ngrok.com tls
+ExecStart=/usr/bin/ssh -R www.reciperadar.com:443:localhost:443 tunnel.eu.ngrok.com tls
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Until this point, the production server had been listening on the `http` network service port, purely to redirect any traffic landing there to the `https` port.

To free up some `ngrok` tunnels, this change removes `http` service.  As a side-effect there's an ugly error message when visiting `http://www.reciperadar.com` (without HTTPS) - hopefully this is a rare case and there may be a better way to deal with this in future (either via `ngrok` or IPv6 or some other solution).