### PR TITLE
Enable countly compliance-hub plugin

### DIFF
--- a/k8s/services/countly-api-deployment.yml
+++ b/k8s/services/countly-api-deployment.yml
@@ -32,7 +32,7 @@ spec:
           timeoutSeconds: 3
         env:
           - name: COUNTLY_PLUGINS
-            value: "web,plugins,locale,browser,sources,views,logger,systemlogs,errorlogs,crashes,slipping-away-users,server-stats,times-of-day"
+            value: "web,plugins,locale,browser,sources,views,logger,systemlogs,errorlogs,crashes,slipping-away-users,server-stats,times-of-day,compliance-hub"
           - name: COUNTLY_CONFIG_API_FILESTORAGE
             value: gridfs
           - name: COUNTLY_CONFIG_API_MONGODB_HOST

--- a/k8s/services/countly-frontend-deployment.yml
+++ b/k8s/services/countly-frontend-deployment.yml
@@ -32,7 +32,7 @@ spec:
           timeoutSeconds: 3
         env:
           - name: COUNTLY_PLUGINS
-            value: "web,plugins,locale,browser,sources,views,logger,systemlogs,errorlogs,crashes,slipping-away-users,server-stats,times-of-day"
+            value: "web,plugins,locale,browser,sources,views,logger,systemlogs,errorlogs,crashes,slipping-away-users,server-stats,times-of-day,compliance-hub"
           - name: COUNTLY_CONFIG_API_FILESTORAGE
             value: gridfs
           - name: COUNTLY_CONFIG_API_MONGODB_HOST


### PR DESCRIPTION
Relates to https://github.com/openculinary/frontend/issues/27

Enable the `countly` [compliance-hub](https://count.ly/plugins/compliance-hub) plugin, which should assist in managing compliance requests and issues.