### PR TITLE
Remove CSIMigration feature gate workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,16 +123,6 @@ cp etc/mongodb/mongodb.conf /etc/mongodb.conf
 cp etc/haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg
 ```
 
-## Disable kubelet CSIMigration via feature flag
-```
-vim /var/lib/kubelet/config.yaml
-...
-featureGates:
-  CSIMigration: false
-```
-See [this issue](https://github.com/kubernetes/kubernetes/issues/86094) for
-details.
-
 ## Start system services
 ```
 for service in systemd-networkd elasticsearch postgresql rabbitmq-server squid mongodb haproxy crio kubelet;


### PR DESCRIPTION
As per details in https://github.com/kubernetes/kubernetes/issues/86094 , the `CSINode` failures on startup are a symptom of running a `v1.16` Kubernetes `kubelet` against a `v1.17` Kubernetes `api-server`.

The cluster API server has now been upgraded to `v1.17` via `kubeadm upgrade`, and this workaround to disable `CSIMigration` is no longer required.