### PR TITLE
Enable HTTP content compression

### DIFF
--- a/etc/haproxy/haproxy.cfg
+++ b/etc/haproxy/haproxy.cfg
@@ -8,7 +8,7 @@ defaults
     timeout server  50000
     default-server init-addr last,libc,none
     compression algo gzip
-    compression type application/javascript application/octet-stream font/woff font/woff2 image/png image/x-icon text/css text/html
+    compression type application/javascript application/json application/octet-stream font/woff font/woff2 image/png image/x-icon text/css text/html
 
 frontend http-in
     bind *:80

--- a/etc/haproxy/haproxy.cfg
+++ b/etc/haproxy/haproxy.cfg
@@ -7,6 +7,8 @@ defaults
     timeout client  50000
     timeout server  50000
     default-server init-addr last,libc,none
+    compression algo gzip
+    compression type application/javascript font/woff font/woff2 image/png image/x-icon text/css text/html
 
 frontend http-in
     bind *:80

--- a/etc/haproxy/haproxy.cfg
+++ b/etc/haproxy/haproxy.cfg
@@ -8,7 +8,7 @@ defaults
     timeout server  50000
     default-server init-addr last,libc,none
     compression algo gzip
-    compression type application/javascript font/woff font/woff2 image/png image/x-icon text/css text/html
+    compression type application/javascript application/octet-stream font/woff font/woff2 image/png image/x-icon text/css text/html
 
 frontend http-in
     bind *:80


### PR DESCRIPTION
Enable HTTP content compression via `haproxy` (prior to Kubernetes ingress).  This ensures that compression is applied regardless of the backend service/endpoint invoked.