### PR TITLE
Ensure blog redirects are root-relative

### DIFF
--- a/etc/haproxy/haproxy.cfg
+++ b/etc/haproxy/haproxy.cfg
@@ -53,6 +53,7 @@ backend api
 
 backend blog
     http-request set-header Host blog
+    http-response replace-header Location http://blog/(.*) /\1
     server ingress 127.0.0.1:30080
 
 backend countly


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This configuration change solves an issue where external web requests to the RecipeRadar blog would be redirected to an incorrectly-named host (`blog` instead of `blog.reciperadar.com`).

### Briefly summarize the changes
1. Strip the `http://<service>/` Kubernetes service hostname in response `Location` headers

### How have the changes been tested?
1. Tested via an instance of `haproxy` + RecipeRadar cluster

**List any issues that this change relates to**
Fixes #11 