### PR TITLE
Remove /api path prefix from HTTP requests forwarded to the 'api' service

### DIFF
--- a/etc/haproxy/haproxy.cfg
+++ b/etc/haproxy/haproxy.cfg
@@ -49,6 +49,7 @@ backend analytics
 
 backend api
     http-request set-header Host api
+    http-request replace-path /api/(.*) /\1
     server ingress 127.0.0.1:30080
 
 backend blog


### PR DESCRIPTION
Once the `/api` path prefix has been removed from HTTP endpoints in the `api` service (as proposed in openculinary/api#78), we should trim that part of the URI path from forwarded client requests.

**List any issues that this change relates to**
Resolves #23.
Depends on openculinary/api#78
Depends on openculinary/backend#18