### PR TITLE
Enable haproxy ingress to diagnostics service

### DIFF
--- a/etc/haproxy/haproxy.cfg
+++ b/etc/haproxy/haproxy.cfg
@@ -21,9 +21,11 @@ frontend https-in
     use_backend blog if blog_request
 
     acl api_request path_beg /api
+    acl diagnostics_request path_beg /diagnostics
     acl img_request path_beg /images/recipes
 
     use_backend api if api_request
+    use_backend diagnostics if diagnostics_request
     use_backend image-retrieval if img_request
     default_backend frontend
 
@@ -37,6 +39,11 @@ backend api
 backend blog
     http-request set-header Host blog
     http-response replace-header Location http://blog/(.*) /\1
+    server ingress 127.0.0.1:30080
+
+backend diagnostics
+    http-request set-header Host diagnostics
+    http-request set-path %[path,regsub(^/diagnostics/,/)]
     server ingress 127.0.0.1:30080
 
 backend frontend


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
As part of openculinary/frontend#94, the [`diagnostics`](https://github.com/openculinary/diagnostics) service has been built which provides information about current and historic recipe content.

As noted in openculinary/backend#19, an intentional decision has been made not to provide direct access to the `backend` service where this data is sourced.  Instead the `diagnostics` service provides a limited set of endpoints with which callers can interact.

### Briefly summarize the changes
1. Allow ingress to the `diagnostics` service via requests with a `/diagnostics` prefix

### How have the changes been tested?
1. Local development testing

**List any issues that this change relates to**
Relates to openculinary/frontend#94.