### PR TITLE
Add domain images to image-retrieval acl

### DIFF
--- a/etc/haproxy/haproxy.cfg
+++ b/etc/haproxy/haproxy.cfg
@@ -22,6 +22,7 @@ frontend https-in
 
     acl api_request path_beg /api
     acl diagnostics_request path_reg ^\/diagnostics\/(.+)
+    acl img_request path_beg /images/domains
     acl img_request path_beg /images/recipes
 
     use_backend api if api_request


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This is a small configuration tweak for `haproxy` to enable retrieval of per-domain icon images, as provided by openculinary/image-retrieval#6.

### Briefly summarize the changes
1. Add `/images/domains` to the set of request prefixes which are routed to the [`image-retrieval`](https://github.com/openculinary/image-retrieval) service 

### How have the changes been tested?
1. Local development testing

**List any issues that this change relates to**
Relates to openculinary/backend#27
Relates to openculinary/image-retrieval#6