### PR TITLE
RFC9239: Update MIME type within content-type response headers for JavaScript content

### DIFF
--- a/etc/haproxy/haproxy.cfg
+++ b/etc/haproxy/haproxy.cfg
@@ -48,6 +48,8 @@ backend diagnostics
 backend frontend
     # RFC9239, May 2022: 'text/javascript' replaces 'application/javascript'
     # https://www.rfc-editor.org/rfc/rfc9239#section-6
+    # NOTE: There is a feature request in nginx for this to become the default
+    # https://trac.nginx.org/nginx/ticket/1407
     http-response replace-header Content-Type ^application/javascript(;.*)$ text/javascript\1
 
     http-request set-header Host frontend

--- a/etc/haproxy/haproxy.cfg
+++ b/etc/haproxy/haproxy.cfg
@@ -48,7 +48,7 @@ backend diagnostics
 backend frontend
     # RFC9239, May 2022: 'text/javascript' replaces 'application/javascript'
     # https://www.rfc-editor.org/rfc/rfc9239#section-6
-    http-response replace-header Content-Type ^application/javascript$ text/javascript
+    http-response replace-header Content-Type ^application/javascript(;.*)$ text/javascript\1
 
     http-request set-header Host frontend
     http-response replace-header Location http://frontend/(.*) /\1

--- a/etc/haproxy/haproxy.cfg
+++ b/etc/haproxy/haproxy.cfg
@@ -46,6 +46,10 @@ backend diagnostics
     server ingress 127.0.0.1:30080
 
 backend frontend
+    # RFC9239, May 2022: 'text/javascript' replaces 'application/javascript'
+    # https://www.rfc-editor.org/rfc/rfc9239#section-6
+    http-response replace-header Content-Type ^application/javascript$ text/javascript
+
     http-request set-header Host frontend
     http-response replace-header Location http://frontend/(.*) /\1
     server ingress 127.0.0.1:30080


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
`<script type="text/javascript" ...` and `Content-Type: application/javascript` are both MIME types that are widely read and understood intuitively.  It seems like [RFC9239](https://www.rfc-editor.org/rfc/rfc9239) makes an attempt to address a technical/specification inconsistency between the two of them.

In particular, [section six](https://www.rfc-editor.org/rfc/rfc9239#section-6) of RFC9239 ("IANA Considerations") states:

> The media type registrations herein are divided into two major categories: (1) the sole media type "text/javascript", which is now in common usage and (2) all of the media types that are obsolete (i.e., "application/ecmascript", "application/javascript", "application/x-ecmascript", "application/x-javascript", "text/ecmascript", "text/javascript1.0", "text/javascript1.1", "text/javascript1.2", "text/javascript1.3", "text/javascript1.4", "text/javascript1.5", "text/jscript", "text/livescript", and "text/x-ecmascript").

### Briefly summarize the changes
1. When handling outbound responses from the `frontend` application, if the `Content-Type` header matches the `application/javascript` MIME type, perform a string replacement at the start of the header to replace `application/javascript` with `text/javascript`.

### How have the changes been tested?
1. Deployed to an `haproxy` instance and tested with some example requests to an instance of the `frontend` application