### PR TITLE
Incident report: 2024-08-28 site outage (container images unavailable)

### DIFF
--- a/docs/incidents/2024-08-28-site-outage.md
+++ b/docs/incidents/2024-08-28-site-outage.md
@@ -4,4 +4,6 @@
 
 ## What went wrong?
 
+## What went well?
+
 ## Prevention Measures

--- a/docs/incidents/2024-08-28-site-outage.md
+++ b/docs/incidents/2024-08-28-site-outage.md
@@ -26,3 +26,9 @@
 There are a small number of semi-manual operational processes that our team already performs on a regular basis, such as rotation of certificates.
 
 Non-trivial processes should be documented, and stale container image cleanup is a good candidate for documentation.
+
+**Alerting**
+
+We discontinued automated alerting for the service in May of Y2021, and the team has expressed a preference not to use automated alerting.
+
+The recommended action here is to remind the team to regularly check the status of the site when they feel comfortable to; we will not add automated alerting at this time.

--- a/docs/incidents/2024-08-28-site-outage.md
+++ b/docs/incidents/2024-08-28-site-outage.md
@@ -16,4 +16,6 @@
 
 ## What went well?
 
+- The system's Search API remained available throughout the website outage
+
 ## Prevention Measures

--- a/docs/incidents/2024-08-28-site-outage.md
+++ b/docs/incidents/2024-08-28-site-outage.md
@@ -12,6 +12,8 @@
 
 ## What went wrong?
 
+- Essential current container images were removed from production
+
 ## What went well?
 
 ## Prevention Measures

--- a/docs/incidents/2024-08-28-site-outage.md
+++ b/docs/incidents/2024-08-28-site-outage.md
@@ -13,6 +13,7 @@
 ## What went wrong?
 
 - Essential current container images were removed from production.
+- Lack of system uptime monitoring caused a delay identifying the outage.
 
 ## What went well?
 

--- a/docs/incidents/2024-08-28-site-outage.md
+++ b/docs/incidents/2024-08-28-site-outage.md
@@ -2,6 +2,14 @@
 
 ## What happened?
 
+- 2024-08-28
+  - 09:?? - Opportunistic maintenance to remove stale container images in production began
+  - 09:30 - The frontend microservice that provides the user-facing website became unavailable (HTTP 5xx responses)
+  - 15:?? - Admin attempts to use the website and notices that it is unavailable
+  - 15:?? - Admin logs into production, notices that the frontend service is failing due to a lack of container images
+  - 15:?? - Admin rebuilds and redeploys the latest copy of the frontend microservice
+  - 15:45 - Availability of the frontend microservice was restored
+
 ## What went wrong?
 
 ## What went well?

--- a/docs/incidents/2024-08-28-site-outage.md
+++ b/docs/incidents/2024-08-28-site-outage.md
@@ -20,3 +20,9 @@
 - The system's Search API remained available throughout the website outage.
 
 ## Prevention Measures
+
+**Operational Processes**
+
+There are a small number of semi-manual operational processes that our team already performs on a regular basis, such as rotation of certificates.
+
+Non-trivial processes should be documented, and stale container image cleanup is a good candidate for documentation.

--- a/docs/incidents/2024-08-28-site-outage.md
+++ b/docs/incidents/2024-08-28-site-outage.md
@@ -3,19 +3,19 @@
 ## What happened?
 
 - 2024-08-28
-  - 09:?? - Opportunistic maintenance to remove stale container images in production began
-  - 09:30 - The frontend microservice that provides the user-facing website became unavailable (HTTP 5xx responses)
-  - 15:?? - Admin attempts to use the website and notices that it is unavailable
-  - 15:?? - Admin logs into production, notices that the frontend service is failing due to a lack of container images
-  - 15:?? - Admin rebuilds and redeploys the latest copy of the frontend microservice
-  - 15:45 - Availability of the frontend microservice was restored
+  - 09:?? - Opportunistic maintenance to remove stale container images in production began.
+  - 09:30 - The frontend microservice that provides the user-facing website became unavailable (HTTP 5xx responses).
+  - 15:?? - Admin attempts to use the website and notices that it is unavailable.
+  - 15:?? - Admin logs into production, notices that the frontend service is failing due to a lack of container images.
+  - 15:?? - Admin rebuilds and redeploys the latest copy of the frontend microservice.
+  - 15:45 - Availability of the frontend microservice was restored.
 
 ## What went wrong?
 
-- Essential current container images were removed from production
+- Essential current container images were removed from production.
 
 ## What went well?
 
-- The system's Search API remained available throughout the website outage
+- The system's Search API remained available throughout the website outage.
 
 ## Prevention Measures

--- a/docs/incidents/2024-08-28-site-outage.md
+++ b/docs/incidents/2024-08-28-site-outage.md
@@ -1,0 +1,7 @@
+# Site Outage
+
+## What happened?
+
+## What went wrong?
+
+## Prevention Measures


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The RecipeRadar service suffered an outage for approximately 6 hours 15 minutes commencing on 2024-08-28.  This report is a writeup of the timeline of events that contributed to the outage, and the recovery procedures that were used.

The goal is to identify possible changes to our practices that should reduce the chance of a similar incident occurring again in future.

Resolves #44.