### PR TITLE
Documentation: update with notes from creation of standby node

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ curl -XPUT -H 'Content-Type: application/json' 'http://192.168.100.1:9200/_snaps
 
 #### Initialize cluster
 ```
-kubeadm init --apiserver-advertise-address=192.168.100.1 --pod-network-cidr=172.16.0.0/12
+kubeadm init --config k8s/kubeadm-config.yaml
 ```
 
 ```
@@ -199,7 +199,7 @@ sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
 #### Deploy kubernetes infrastructure components
 ```
-for component in k8s/*;
+for component in ingress networking services;
 do
 	kubectl apply -f ${component}
 done;

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ sudo chown $(id -u):$(id -g) $HOME/.kube/config
 ```
 for component in ingress networking services;
 do
-	kubectl apply -f ${component}
+	kubectl apply -f k8s/${component}
 done;
 ```
 

--- a/k8s/kubeadm-config.yaml
+++ b/k8s/kubeadm-config.yaml
@@ -1,0 +1,12 @@
+kind: ClusterConfiguration
+apiVersion: kubeadm.k8s.io/v1beta3
+networking:
+  podSubnet: "172.16.0.0/12"
+---
+kind: InitConfiguration
+apiVersion: kubeadm.k8s.io/v1beta3
+localAPIEndpoint:
+  advertiseAddress: "192.168.100.1"
+---
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
To provide ample maintenance time to replace a faulty system drive in our production server, it's worthwhile to spin up a secondary standby host that can handle traffic during the reinstallation of the server.

This process is also useful to confirm that we can run the production service from multiple machines, a property that may be useful in future.

This changeset documents the process involved in creating and running the standby host.

Note: the standby host has been installed in an unprivileged LXC container on a physically separate machine.

### Briefly summarize the changes
1. TODO: document the LXC setup steps

### How have the changes been tested?
1. Local development testing -- in particular, with three foundational microservices ([`api`](https://github.com/openculinary/api/), [`backend`](https://github.com/openculinary/backend/) and [`frontend`](https://github.com/openculinary/api/)), and all of the essential system services (OpenSearch, PostgreSQL, HAProxy, RabbitMQ) running within the container, the site was opened successfully from a web browser outside the container, and a successfully recipe search was performed with subsequent confirmation that an event was logged to the `events.searches` database table as expected.

**List any issues that this change relates to**
Supports/documents #47.