### PR TITLE
Squid: cleanup: remove stale/not-recently-used 'tor' and 'privoxy' configuration

### DIFF
--- a/etc/squid/conf.d/recipe-radar.conf
+++ b/etc/squid/conf.d/recipe-radar.conf
@@ -3,11 +3,6 @@ http_port 3128 name=standard \
     ssl-bump generate-host-certificates=on dynamic_cert_mem_cache_size=4MB \
     cert=/etc/squid/certificates/ca.crt key=/etc/squid/certificates/ca.key
 
-# Listener for privacy-upgraded outbound traffic
-http_port 3443 name=private \
-    ssl-bump generate-host-certificates=on dynamic_cert_mem_cache_size=4MB \
-    cert=/etc/squid/certificates/ca.crt key=/etc/squid/certificates/ca.key
-
 # SSL-bump all connections
 ssl_bump bump all
 
@@ -27,8 +22,3 @@ offline_mode on
 # Send all standard traffic direct
 acl standard_traffic myportname standard
 always_direct allow standard_traffic
-
-# Send all private traffic via privoxy
-cache_peer 127.0.0.1 parent 8118 0 no-query no-digest default
-acl private_traffic myportname private
-never_direct allow private_traffic


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Early in the development of RecipeRadar, the configuration of Squid anticipated that it might be useful to use `tor` to retrieve some recipe webpages, due to the potential for the single-IP webcrawler to be blocked, and `tor` as an open source and somewhat designed-for-neutrality network.  Related to this, `privoxy` provides an open source HTTP proxy that uses `tor` to anonymize network requests.

We have not used this anonymizing functionality in Y2023 or Y2024, and do not currently anticipate that we are likely to enable it, largely because we expect that many recipe websites will block or otherwise bias -- for somewhat understandable reasons -- against `tor`-originated network traffic.

A more forward-looking approach to ensuring unbiased recipe webpage content could be to use datasets such as CommonCrawl -- however we will also want to ensure that we're doing so in an acceptable manner.

### Briefly summarize the changes
1. Remove `tor` and `privoxy` related settings from our customized Squid config.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
Resolves #51.