### PR TITLE
Squid: permissions: allow 'localhost' to use 'PURGE' method

### DIFF
--- a/etc/squid/conf.d/recipe-radar.conf
+++ b/etc/squid/conf.d/recipe-radar.conf
@@ -24,6 +24,11 @@ via off
 refresh_pattern . 1440 100% 525600 override-expire override-lastmod ignore-reload ignore-no-store ignore-private 
 offline_mode on
 
+# Allow localhost to purge content
+acl purge method PURGE
+http_access allow purge localhost
+http_access deny purge
+
 # Send all standard traffic direct
 acl standard_traffic myportname standard
 always_direct allow standard_traffic


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
To allow us to purge cached content when we deem necessary, we should provide limited administrative access to [Squid's cache purge mechanism](https://wiki.squid-cache.org/SquidFaq/OperatingSquid#how-can-i-purge-an-object-from-my-cache).

### Briefly summarize the changes
1. Allow `localhost` only to use the non-standard HTTP `PURGE` verb to purge content from the Squid cache, by updating the `recipe-radar.conf` Squid config file.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
Tangentially relates to https://github.com/openculinary/crawler/issues/31