### PR TITLE
haproxy: remove RFC9239 replacement of MIME type 'application/javascript' with 'text/javascript'

### DIFF
--- a/etc/haproxy/haproxy.cfg
+++ b/etc/haproxy/haproxy.cfg
@@ -53,12 +53,6 @@ backend diagnostics
     server ingress 127.0.0.1:30080
 
 backend frontend
-    # RFC9239, May 2022: 'text/javascript' replaces 'application/javascript'
-    # https://www.rfc-editor.org/rfc/rfc9239#section-6
-    # NOTE: There is a feature request in nginx for this to become the default
-    # https://trac.nginx.org/nginx/ticket/1407
-    http-response replace-header Content-Type ^application/javascript(;.*)$ text/javascript\1
-
     http-request set-header Host frontend
     http-response replace-header Location http://frontend/(.*) /\1
     server ingress 127.0.0.1:30080


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This is a cleanup to remove some HTTP `Content-Type` header (MIME type) configuration that is being relocated to the `frontend` service `nginx` configuration.

### Briefly summarize the changes
1. Remove the `Content-Type` HTTP response header substitution logic from the `haproxy` configuration file.

### How have the changes been tested?
1. N/A

**List any issues that this change relates to**
Relates to https://github.com/openculinary/frontend/issues/266

Edit: remove 'pending' note from issue crossreference.